### PR TITLE
Update npm package for developers-agent-toolkit to be organization scoped instead

### DIFF
--- a/.github/workflows/npm-agent-toolkit-release.yml
+++ b/.github/workflows/npm-agent-toolkit-release.yml
@@ -1,4 +1,4 @@
-name: NPM Release mastercard-developers-agent-toolkit
+name: NPM Release @mastercard/developers-agent-toolkit
 
 on:
   workflow_dispatch: {}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,34 @@
 
 The Mastercard Developers Agent Toolkit allows popular agent frameworks (currently Model Context Protocol - MCP) to integrate with [Mastercard Developers Platform](https://developer.mastercard.com) for service discovery and integration guides.
 
+## Key Features
+
+* **Service Discovery**: Enables agents to programmatically discover available services on the Mastercard Developers platform.
+* **Integration Guide Access**: Provides access to detailed documentation and integration guides.
+* **Flexible Deployment**: Can be run as a standalone server or integrated as a library in TypeScript/JavaScript projects.
+* **MCP-Based**: Built on the Model Context Protocol (MCP) for standardized communication.
+
+## Supported Tool Calls
+
+The toolkit provides the following tools for agents to use:
+
+### Services
+
+* `get-services-list`: Lists all available Mastercard Developers Products and Services with their basic information including title, description, and service id.
+
+### Documentation
+
+* `get-documentation`: Provides an overview of all available documentation for a specific Mastercard service including section titles, descriptions, and navigation links.
+* `get-documentation-section-content`: Retrieves the complete content for a specific documentation section.
+* `get-documentation-page`: Retrieves the complete content of a specific documentation page.
+* `get-oauth10a-integration-guide`: Retrieves the comprehensive OAuth 1.0a integration guide.
+* `get-openbanking-integration-guide`: Retrieves the comprehensive Open Banking integration guide.
+
+### API Operations
+
+* `get-api-operation-list`: Provides a summary of all API operations for a specific Mastercard API specification including HTTP methods, request paths, titles, and descriptions.
+* `get-api-operation-details`: Provides detailed information about a specific API operation including parameter definitions, request and response schemas, and technical specifications.
+
 ## Model Context Protocol
 
 We provide a standalone Model Context Protocol (MCP) server that can be used with MCP clients.
@@ -22,14 +50,14 @@ For more details for the configuration options, see [modelcontextprotocol](model
 If you want to use the package in your project, you can install it using npm:
 
 ```bash
-npm install --save mastercard-developers-agent-toolkit
+npm install --save @mastercard/developers-agent-toolkit
 ```
 
 Requirements
 - Node 18+
 
 ```javascript
-import { MastercardDevelopersMCPServer } from "mastercard-developers-agent-toolkit/mcp";
+import { MastercardDevelopersMCPServer } from "@mastercard/developers-agent-toolkit/mcp";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
 const server = new MastercardDevelopersMCPServer({});
@@ -47,3 +75,11 @@ main().catch((error) => {
 ```
 
 For more details, checkout [typescript](typescript/README.md) directory
+
+## Contributing
+
+Contributions are welcome. Please feel free to submit a pull request or open an issue to report a bug or suggest a feature.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/modelcontextprotocol/package-lock.json
+++ b/modelcontextprotocol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mastercard-developers-mcp",
-  "version": "0.1.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mastercard-developers-mcp",
-      "version": "0.1.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.3",

--- a/modelcontextprotocol/package.json
+++ b/modelcontextprotocol/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.0",
   "name": "mastercard-developers-mcp",
   "homepage": "https://github.com/mastercard/developers-agent-toolkit/tree/main/modelcontextprotocol",
   "description": "MCP server for Mastercard Developers Platform",

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -10,7 +10,7 @@ The Mastercard Developers Agent Toolkit allows popular agent frameworks (current
 ## Installation
 
 ```bash
-npm install --save mastercard-developers-agent-toolkit
+npm install --save @mastercard/developers-agent-toolkit
 ```
 
 ### Requirements
@@ -28,7 +28,7 @@ You can optionally specify `service` or `apiSpecification` as part of the config
 If you specify `service` or `api-specification` then the `get-services-list` tool will be disabled.
 
 ```typescript
-import { MastercardDevelopersMCPServer } from 'mastercard-developers-agent-toolkit/mcp';
+import { MastercardDevelopersMCPServer } from '@mastercard/developers-agent-toolkit/mcp';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 const server = new MastercardDevelopersMCPServer({

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mastercard-developers-agent-toolkit",
-  "version": "0.1.3",
+  "name": "@mastercard/developers-agent-toolkit",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mastercard-developers-agent-toolkit",
-      "version": "0.1.3",
+      "name": "@mastercard/developers-agent-toolkit",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.3",
-  "name": "mastercard-developers-agent-toolkit",
+  "version": "0.1.0",
+  "name": "@mastercard/developers-agent-toolkit",
   "homepage": "https://github.com/mastercard/developers-agent-toolkit",
   "description": "Agent Toolkit for Mastercard Developers Platform",
   "author": "Mastercard",


### PR DESCRIPTION
Move the package to `@mastercard` organizaton so it is released to npm under `@mastercard/developers-agent-tookit`