### PR TITLE
Rename 'Open Banking' to 'Open Finance'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="https://developer.mastercard.com/_/_/src/global/assets/svg/mcdev-logo-dark.svg" alt="mastercard developers logo">
 </picture>
 
-The Mastercard Developers Agent Toolkit allows popular agent frameworks (currently Model Context Protocol - MCP) to integrate with [Mastercard Developers Platform](https://developer.mastercard.com) for service discovery and integration guides.
+The Mastercard Developers Agent Toolkit allows popular agent frameworks (currently Model Context Protocol - MCP) to integrate with [Mastercard Developers](https://developer.mastercard.com) for service discovery and integration guides.
 
 ## Key Features
 
@@ -28,7 +28,7 @@ The toolkit provides the following tools for agents to use:
 * `get-documentation-section-content`: Retrieves the complete content for a specific documentation section.
 * `get-documentation-page`: Retrieves the complete content of a specific documentation page.
 * `get-oauth10a-integration-guide`: Retrieves the comprehensive OAuth 1.0a integration guide.
-* `get-openbanking-integration-guide`: Retrieves the comprehensive Open Banking integration guide.
+* `get-openfinance-integration-guide`: Retrieves the comprehensive Open Finance integration guide.
 
 ### API Operations
 

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -14,7 +14,7 @@ This MCP server acts as a bridge between MCP clients and Mastercard Developers r
 - List available Mastercard services
 - Query API specifications and their operations
 - Access documentation for each service
-- Retrieve integration guides for OAuth 1.0a and Open Banking
+- Retrieve integration guides for OAuth 1.0a and Open Finance
 
 ## Available Tools
 
@@ -40,7 +40,7 @@ This MCP server acts as a bridge between MCP clients and Mastercard Developers r
 
 - **`get-oauth10a-integration-guide`**: Retrieves the comprehensive OAuth 1.0a integration guide including step-by-step instructions, code examples, and best practices for Mastercard APIs.
 
-- **`get-openbanking-integration-guide`**: Retrieves the comprehensive Open Banking integration guide including setup instructions, API usage examples, and implementation best practices.
+- **`get-openfinance-integration-guide`**: Retrieves the comprehensive Open Finance integration guide including setup instructions, API usage examples, and implementation best practices.
 
 ## Configuration Options
 
@@ -78,7 +78,7 @@ To use this server with MCP clients like Claude Desktop, add it to your MCP conf
       "args": [
         "-y",
         "@mastercard/developers-mcp",
-        "--service=https://developer.mastercard.com/open-banking-us/documentation/"
+        "--service=https://developer.mastercard.com/open-finance-us/documentation/"
       ]
     }
   }
@@ -95,7 +95,7 @@ To use this server with MCP clients like Claude Desktop, add it to your MCP conf
       "args": [
         "-y",
         "@mastercard/developers-mcp",
-        "--api-specification=https://developer.mastercard.com/open-banking-us/swagger/openbanking-us.yaml"
+        "--api-specification=https://developer.mastercard.com/open-finance-us/swagger/openfinance-us.yaml"
       ]
     }
   }
@@ -168,10 +168,10 @@ The server runs on stdio and will be available for MCP client connections.
 
 ```bash
 # Pre-configure with a documentation URL
-npm run start -- --service=https://developer.mastercard.com/open-banking-us/documentation/
+npm run start -- --service=https://developer.mastercard.com/open-finance-us/documentation/
 
 # Pre-configure with an API specification path
-npm run start -- --api-specification=https://static.developer.mastercard.com/content/open-banking-us/swagger/openbanking-us.yaml
+npm run start -- --api-specification=https://static.developer.mastercard.com/content/open-finance-us/swagger/openfinance-us.yaml
 ```
 
 ### To build the DXT file
@@ -192,4 +192,4 @@ npx @modelcontextprotocol/inspector node dist/index.js
 
 - [Mastercard Developers Platform](https://developer.mastercard.com/)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
-- [MCP SDK](https://github.com/modelcontextprotocol/sdk)
+- [MCP SDKs](https://github.com/modelcontextprotocol)

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -95,7 +95,7 @@ To use this server with MCP clients like Claude Desktop, add it to your MCP conf
       "args": [
         "-y",
         "@mastercard/developers-mcp",
-        "--api-specification=https://developer.mastercard.com/open-finance-us/swagger/openfinance-us.yaml"
+        "--api-specification=https://developer.mastercard.com/open-finance-us/swagger/openbanking-us.yaml"
       ]
     }
   }
@@ -171,7 +171,7 @@ The server runs on stdio and will be available for MCP client connections.
 npm run start -- --service=https://developer.mastercard.com/open-finance-us/documentation/
 
 # Pre-configure with an API specification path
-npm run start -- --api-specification=https://static.developer.mastercard.com/content/open-finance-us/swagger/openfinance-us.yaml
+npm run start -- --api-specification=https://static.developer.mastercard.com/content/open-finance-us/swagger/openbanking-us.yaml
 ```
 
 ### To build the DXT file

--- a/modelcontextprotocol/dxt/manifest.json
+++ b/modelcontextprotocol/dxt/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "display_name": "Mastercard Developers MCP",
   "description": "Access Mastercard Developers APIs, documentation, and specifications through MCP",
-  "long_description": "This extension provides seamless access to Mastercard Developers APIs, comprehensive documentation, and API specifications. It enables developers to query available services, retrieve detailed API operation information, access documentation sections, and get integration guides directly.\n\n**Key Features:**\n- List all available Mastercard services\n- Access comprehensive documentation and specific sections\n- Retrieve OAuth 1.0a and Open Banking integration guides\n- Get detailed API operation information including parameters and schemas\n- Query API specifications and operation details\n\n**Use Cases:**\n- API discovery and exploration\n- Documentation lookup during development\n- Integration planning and implementation\n- Authentication and authorization guidance",
+  "long_description": "This extension provides seamless access to Mastercard Developers APIs, comprehensive documentation, and API specifications. It enables developers to query available services, retrieve detailed API operation information, access documentation sections, and get integration guides directly.\n\n**Key Features:**\n- List all available Mastercard services\n- Access comprehensive documentation and specific sections\n- Retrieve OAuth 1.0a and Open Finance integration guides\n- Get detailed API operation information including parameters and schemas\n- Query API specifications and operation details\n\n**Use Cases:**\n- API discovery and exploration\n- Documentation lookup during development\n- Integration planning and implementation\n- Authentication and authorization guidance",
   "author": {
     "name": "Mastercard Developers",
     "email": "developer@mastercard.com",
@@ -63,8 +63,8 @@
       "description": "Retrieves the comprehensive OAuth 1.0a integration guide including step-by-step instructions, code examples, and best practices for Mastercard APIs."
     },
     {
-      "name": "openbanking-integration-guide",
-      "description": "Retrieves the comprehensive Open Banking integration guide including setup instructions, API usage examples, and implementation best practices."
+      "name": "openfinance-integration-guide",
+      "description": "Retrieves the comprehensive Open Finance integration guide including setup instructions, API usage examples, and implementation best practices."
     }
   ]
 }

--- a/modelcontextprotocol/src/__tests__/index.test.ts
+++ b/modelcontextprotocol/src/__tests__/index.test.ts
@@ -19,24 +19,24 @@ describe('parseArgs function', () => {
 
     it('should parse valid api-specification-path argument', () => {
       const result = parseArgs([
-        '--api-specification=https://static.developer.mastercard.com/content/open-banking-us/swagger/spec.yaml',
+        '--api-specification=https://static.developer.mastercard.com/content/open-finance-us/swagger/spec.yaml',
       ]);
       expect(result).toEqual({
         apiSpecification:
-          'https://static.developer.mastercard.com/content/open-banking-us/swagger/spec.yaml',
+          'https://static.developer.mastercard.com/content/open-finance-us/swagger/spec.yaml',
       });
     });
 
     it('should parse both arguments together', () => {
       const result = parseArgs([
         '--service=https://developer.mastercard.com/payment-gateway/documentation/',
-        '--api-specification=https://static.developer.mastercard.com/content/open-banking-us/swagger/spec.yaml',
+        '--api-specification=https://static.developer.mastercard.com/content/open-finance-us/swagger/spec.yaml',
       ]);
       expect(result).toEqual({
         service:
           'https://developer.mastercard.com/payment-gateway/documentation/',
         apiSpecification:
-          'https://static.developer.mastercard.com/content/open-banking-us/swagger/spec.yaml',
+          'https://static.developer.mastercard.com/content/open-finance-us/swagger/spec.yaml',
       });
     });
 
@@ -83,14 +83,14 @@ describe('main function', () => {
     process.argv = [
       'node',
       'index.js',
-      '--service=https://developer.mastercard.com/open-banking-us/documentation/',
+      '--service=https://developer.mastercard.com/open-finance-us/documentation/',
     ];
 
     await main();
 
     expect(MastercardDevelopersAgentToolkit).toHaveBeenCalledWith({
       service:
-        'https://developer.mastercard.com/open-banking-us/documentation/',
+        'https://developer.mastercard.com/open-finance-us/documentation/',
     });
   });
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -5,7 +5,7 @@
   <img src="https://developer.mastercard.com/_/_/src/global/assets/svg/mcdev-logo-dark.svg" alt="mastercard developers logo">
 </picture>
 
-The Mastercard Developers Agent Toolkit allows popular agent frameworks (currently Model Context Protocol - MCP) to integrate with [Mastercard Developers Platform](https://developer.mastercard.com) for service discovery and integration guides.
+The Mastercard Developers Agent Toolkit allows popular agent frameworks (currently Model Context Protocol - MCP) to integrate with [Mastercard Developers](https://developer.mastercard.com) for service discovery and integration guides.
 
 ## Installation
 
@@ -33,7 +33,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 const server = new MastercardDevelopersAgentToolkit({
   configuration: {
-    service: 'https://developer.mastercard.com/open-banking-us/documentation',
+    service: 'https://developer.mastercard.com/open-finance-us/documentation',
   },
 });
 
@@ -53,4 +53,4 @@ main().catch((error) => {
 
 - [Mastercard Developers Platform](https://developer.mastercard.com/)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
-- [MCP SDK](https://github.com/modelcontextprotocol/sdk)
+- [MCP SDKs](https://github.com/modelcontextprotocol)

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mastercard/developers-agent-toolkit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mastercard/developers-agent-toolkit",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "name": "@mastercard/developers-agent-toolkit",
   "homepage": "https://github.com/mastercard/developers-agent-toolkit",
   "description": "Agent Toolkit for Mastercard Developers Platform",

--- a/typescript/src/modelcontextprotocol/__tests__/index.test.ts
+++ b/typescript/src/modelcontextprotocol/__tests__/index.test.ts
@@ -72,10 +72,10 @@ describe('buildContext function', () => {
     it('should parse service URL and extract serviceId', () => {
       const result = buildContext({
         service:
-          'https://developer.mastercard.com/open-banking-us/documentation/',
+          'https://developer.mastercard.com/open-finance-us/documentation/',
       });
       expect(result).toEqual({
-        serviceId: 'open-banking-us',
+        serviceId: 'open-finance-us',
       });
     });
 
@@ -104,10 +104,10 @@ describe('buildContext function', () => {
     it('should handle service IDs with hyphens and numbers', () => {
       const result = buildContext({
         service:
-          'https://developer.mastercard.com/open-banking-us-v2/documentation/',
+          'https://developer.mastercard.com/open-finance-us-v2/documentation/',
       });
       expect(result).toEqual({
-        serviceId: 'open-banking-us-v2',
+        serviceId: 'open-finance-us-v2',
       });
     });
   });

--- a/typescript/src/modelcontextprotocol/index.ts
+++ b/typescript/src/modelcontextprotocol/index.ts
@@ -124,7 +124,7 @@ function parseAPISpecificationPathAndServiceId(
     // Try to parse as URL first
     const url = new URL(input);
 
-    // Handle full URL: https://static.developer.mastercard.com/content/open-banking-us/swagger/openbanking-us.yaml
+    // Handle full URL: https://static.developer.mastercard.com/content/open-finance-us/swagger/openfinance-us.yaml
     if (url.hostname !== 'static.developer.mastercard.com') {
       return null;
     }

--- a/typescript/src/modelcontextprotocol/index.ts
+++ b/typescript/src/modelcontextprotocol/index.ts
@@ -124,7 +124,7 @@ function parseAPISpecificationPathAndServiceId(
     // Try to parse as URL first
     const url = new URL(input);
 
-    // Handle full URL: https://static.developer.mastercard.com/content/open-finance-us/swagger/openfinance-us.yaml
+    // Handle full URL: https://static.developer.mastercard.com/content/open-finance-us/swagger/openbanking-us.yaml
     if (url.hostname !== 'static.developer.mastercard.com') {
       return null;
     }

--- a/typescript/src/shared/api/__tests__/index.test.ts
+++ b/typescript/src/shared/api/__tests__/index.test.ts
@@ -63,7 +63,7 @@ describe('MastercardAPIClient', () => {
         const requestUrl = new URL(urlString);
         expect(requestUrl.searchParams.get('absolute_urls')).toBe('false');
         expect(urlString).toBe(
-          mcd('/open-banking-us/documentation/llms.txt?absolute_urls=false')
+          mcd('/open-finance-us/documentation/llms.txt?absolute_urls=false')
         );
         return Promise.resolve({
           ok: true,
@@ -72,7 +72,7 @@ describe('MastercardAPIClient', () => {
         } as Response);
       });
 
-      const result = await client.getDocumentation('open-banking-us');
+      const result = await client.getDocumentation('open-finance-us');
       expect(result).toBe('documentation content');
     });
   });
@@ -88,7 +88,7 @@ describe('MastercardAPIClient', () => {
         );
         expect(urlString).toBe(
           mcd(
-            '/open-banking-us/documentation/llms-full.txt?absolute_urls=false&section_id=getting-started'
+            '/open-finance-us/documentation/llms-full.txt?absolute_urls=false&section_id=getting-started'
           )
         );
         return Promise.resolve({
@@ -99,7 +99,7 @@ describe('MastercardAPIClient', () => {
       });
 
       const result = await client.getDocumentationSection(
-        'open-banking-us',
+        'open-finance-us',
         'getting-started'
       );
       expect(result).toBe('section content');
@@ -111,7 +111,7 @@ describe('MastercardAPIClient', () => {
       mockFetch.mockImplementation((url: RequestInfo) => {
         const urlString = url.toString();
         expect(urlString).toBe(
-          mcd('/open-banking-us/documentation/api-basics')
+          mcd('/open-finance-us/documentation/api-basics')
         );
         return Promise.resolve({
           ok: true,
@@ -121,7 +121,7 @@ describe('MastercardAPIClient', () => {
       });
 
       const result = await client.getDocumentationPage(
-        '/open-banking-us/documentation/api-basics'
+        '/open-finance-us/documentation/api-basics'
       );
       expect(result).toBe('page content');
     });
@@ -146,7 +146,7 @@ describe('MastercardAPIClient', () => {
         const requestUrl = new URL(urlString);
         expect(requestUrl.searchParams.get('summary')).toBe('true');
         expect(urlString).toBe(
-          mcd('/open-banking-us/swagger/openbanking-us.yaml?summary=true')
+          mcd('/open-finance-us/swagger/openfinance-us.yaml?summary=true')
         );
         return Promise.resolve({
           ok: true,
@@ -156,7 +156,7 @@ describe('MastercardAPIClient', () => {
       });
 
       const result = await client.getApiOperations(
-        '/open-banking-us/swagger/openbanking-us.yaml'
+        '/open-finance-us/swagger/openfinance-us.yaml'
       );
       expect(result).toBe('operations list');
     });
@@ -177,7 +177,7 @@ describe('MastercardAPIClient', () => {
         expect(requestUrl.searchParams.get('path')).toBe('/accounts');
         expect(urlString).toBe(
           mcd(
-            '/open-banking-us/swagger/openbanking-us.yaml?method=GET&path=%2Faccounts'
+            '/open-finance-us/swagger/openfinance-us.yaml?method=GET&path=%2Faccounts'
           )
         );
         return Promise.resolve({
@@ -188,7 +188,7 @@ describe('MastercardAPIClient', () => {
       });
 
       const result = await client.getApiOperationDetails(
-        '/open-banking-us/swagger/openbanking-us.yaml',
+        '/open-finance-us/swagger/openfinance-us.yaml',
         'GET',
         '/accounts'
       );

--- a/typescript/src/shared/api/__tests__/index.test.ts
+++ b/typescript/src/shared/api/__tests__/index.test.ts
@@ -146,7 +146,7 @@ describe('MastercardAPIClient', () => {
         const requestUrl = new URL(urlString);
         expect(requestUrl.searchParams.get('summary')).toBe('true');
         expect(urlString).toBe(
-          mcd('/open-finance-us/swagger/openfinance-us.yaml?summary=true')
+          mcd('/open-finance-us/swagger/openbanking-us.yaml?summary=true')
         );
         return Promise.resolve({
           ok: true,
@@ -156,7 +156,7 @@ describe('MastercardAPIClient', () => {
       });
 
       const result = await client.getApiOperations(
-        '/open-finance-us/swagger/openfinance-us.yaml'
+        '/open-finance-us/swagger/openbanking-us.yaml'
       );
       expect(result).toBe('operations list');
     });
@@ -177,7 +177,7 @@ describe('MastercardAPIClient', () => {
         expect(requestUrl.searchParams.get('path')).toBe('/accounts');
         expect(urlString).toBe(
           mcd(
-            '/open-finance-us/swagger/openfinance-us.yaml?method=GET&path=%2Faccounts'
+            '/open-finance-us/swagger/openbanking-us.yaml?method=GET&path=%2Faccounts'
           )
         );
         return Promise.resolve({
@@ -188,7 +188,7 @@ describe('MastercardAPIClient', () => {
       });
 
       const result = await client.getApiOperationDetails(
-        '/open-finance-us/swagger/openfinance-us.yaml',
+        '/open-finance-us/swagger/openbanking-us.yaml',
         'GET',
         '/accounts'
       );

--- a/typescript/src/shared/tools/documentation/__tests__/getOpenFinanceGuide.test.ts
+++ b/typescript/src/shared/tools/documentation/__tests__/getOpenFinanceGuide.test.ts
@@ -1,7 +1,7 @@
 import {
   execute,
   getParameters,
-} from '@/shared/tools/documentation/getOpenBankingGuide';
+} from '@/shared/tools/documentation/getOpenFinanceGuide';
 import api from '@/shared/api';
 
 jest.mock<typeof api>('@/shared/api');
@@ -13,14 +13,14 @@ describe('execute', () => {
     jest.clearAllMocks();
   });
 
-  it('should get Open Banking integration guide and return it', async () => {
-    const mockResult = 'mock Open Banking guide content';
+  it('should get Open Finance integration guide and return it', async () => {
+    const mockResult = 'mock Open Finance guide content';
     mockApi.getDocumentationPage.mockResolvedValue(mockResult);
 
     const result = await execute({}, {});
 
     expect(mockApi.getDocumentationPage).toHaveBeenCalledWith(
-      '/open-banking-us/documentation/quick-start-guide/index.md'
+      '/open-finance-us/documentation/quick-start-guide/index.md'
     );
     expect(result).toBe(mockResult);
   });

--- a/typescript/src/shared/tools/documentation/getOpenFinanceGuide.ts
+++ b/typescript/src/shared/tools/documentation/getOpenFinanceGuide.ts
@@ -3,8 +3,8 @@ import { Tool, ToolContext } from '@/shared/types';
 import api from '@/shared/api';
 
 const getDescription = (_context: ToolContext): string => {
-  return `Retrieves the comprehensive Open Finance integration guide including setup instructions,
-API usage examples, and implementation best practices.`;
+  return `Retrieves the comprehensive Open Finance (previously known as Open Banking) integration 
+guide including setup instructions, API usage examples, and implementation best practices.`;
 };
 
 export const getParameters = (_context: ToolContext): z.ZodObject<any> => {

--- a/typescript/src/shared/tools/documentation/getOpenFinanceGuide.ts
+++ b/typescript/src/shared/tools/documentation/getOpenFinanceGuide.ts
@@ -3,7 +3,7 @@ import { Tool, ToolContext } from '@/shared/types';
 import api from '@/shared/api';
 
 const getDescription = (_context: ToolContext): string => {
-  return `Retrieves the comprehensive Open Banking integration guide including setup instructions,
+  return `Retrieves the comprehensive Open Finance integration guide including setup instructions,
 API usage examples, and implementation best practices.`;
 };
 
@@ -16,13 +16,13 @@ export const execute = async (
   _params: z.infer<ReturnType<typeof getParameters>>
 ): Promise<string> => {
   return await api.getDocumentationPage(
-    '/open-banking-us/documentation/quick-start-guide/index.md'
+    '/open-finance-us/documentation/quick-start-guide/index.md'
   );
 };
 
-export const getOpenBankingGuide = (context: ToolContext): Tool => ({
-  method: 'get-openbanking-integration-guide',
-  name: 'Get Open Banking Integration Guide',
+export const getOpenFinanceGuide = (context: ToolContext): Tool => ({
+  method: 'get-openfinance-integration-guide',
+  name: 'Get Open Finance Integration Guide',
   description: getDescription(context),
   parameters: getParameters(context),
   execute: (params) => execute(context, params),

--- a/typescript/src/shared/tools/index.ts
+++ b/typescript/src/shared/tools/index.ts
@@ -5,7 +5,7 @@ import { getDocumentation } from '@/shared/tools/documentation/getDocumentation'
 import { getDocumentationSection } from '@/shared/tools/documentation/getDocumentationSection';
 import { getDocumentationPage } from '@/shared/tools/documentation/getDocumentationPage';
 import { getOAuth10aGuide } from '@/shared/tools/documentation/getOAuth10aGuide';
-import { getOpenBankingGuide } from '@/shared/tools/documentation/getOpenBankingGuide';
+import { getOpenFinanceGuide } from '@/shared/tools/documentation/getOpenFinanceGuide';
 
 // Services tools
 import { getServicesList } from '@/shared/tools/services/getServicesList';
@@ -23,7 +23,7 @@ export const tools = (context: ToolContext): Tool[] => [
   getDocumentationSection(context),
   getDocumentationPage(context),
   getOAuth10aGuide(context),
-  getOpenBankingGuide(context),
+  getOpenFinanceGuide(context),
 
   // API Operations
   getApiOperationList(context),

--- a/typescript/src/shared/tools/operations/getApiOperationDetails.ts
+++ b/typescript/src/shared/tools/operations/getApiOperationDetails.ts
@@ -19,10 +19,10 @@ It takes two arguments:
   return `${baseDescription}
 
 It takes three arguments:
-- apiSpecificationPath (str): The path to the API specification file (e.g. The path would be /open-finance-us/swagger/openfinance-us.yaml for
-https://static.developer.mastercard.com/content/open-finance-us/swagger/openfinance-us.yaml,
-https://developer.mastercard.com/open-finance-us/swagger/openfinance-us.yaml,
-or /open-finance-us/swagger/openfinance-us.yaml)
+- apiSpecificationPath (str): The path to the API specification file (e.g. The path would be /open-finance-us/swagger/openbanking-us.yaml for
+https://static.developer.mastercard.com/content/open-finance-us/swagger/openbanking-us.yaml,
+https://developer.mastercard.com/open-finance-us/swagger/openbanking-us.yaml,
+or /open-finance-us/swagger/openbanking-us.yaml)
 - method (str): The HTTP method of the operation (e.g., GET, POST, PUT, DELETE)
 - path (str): The API endpoint path from the specification (e.g., /payments, /accounts/{id})`;
 };
@@ -49,7 +49,7 @@ export const getParameters = (context: ToolContext): z.ZodObject<any> => {
     apiSpecificationPath: z
       .string()
       .describe(
-        'The path to the API specification (e.g., /open-finance-us/swagger/openfinance-us.yaml)'
+        'The path to the API specification (e.g., /open-finance-us/swagger/openbanking-us.yaml)'
       ),
     ...baseParams,
   });

--- a/typescript/src/shared/tools/operations/getApiOperationDetails.ts
+++ b/typescript/src/shared/tools/operations/getApiOperationDetails.ts
@@ -19,10 +19,10 @@ It takes two arguments:
   return `${baseDescription}
 
 It takes three arguments:
-- apiSpecificationPath (str): The path to the API specification file (e.g. The path would be /open-banking-us/swagger/openbanking-us.yaml for
-https://static.developer.mastercard.com/content/open-banking-us/swagger/openbanking-us.yaml,
-https://developer.mastercard.com/open-banking-us/swagger/openbanking-us.yaml,
-or /open-banking-us/swagger/openbanking-us.yaml)
+- apiSpecificationPath (str): The path to the API specification file (e.g. The path would be /open-finance-us/swagger/openfinance-us.yaml for
+https://static.developer.mastercard.com/content/open-finance-us/swagger/openfinance-us.yaml,
+https://developer.mastercard.com/open-finance-us/swagger/openfinance-us.yaml,
+or /open-finance-us/swagger/openfinance-us.yaml)
 - method (str): The HTTP method of the operation (e.g., GET, POST, PUT, DELETE)
 - path (str): The API endpoint path from the specification (e.g., /payments, /accounts/{id})`;
 };
@@ -49,7 +49,7 @@ export const getParameters = (context: ToolContext): z.ZodObject<any> => {
     apiSpecificationPath: z
       .string()
       .describe(
-        'The path to the API specification (e.g., /open-banking-us/swagger/openbanking-us.yaml)'
+        'The path to the API specification (e.g., /open-finance-us/swagger/openfinance-us.yaml)'
       ),
     ...baseParams,
   });

--- a/typescript/src/shared/tools/operations/getApiOperationList.ts
+++ b/typescript/src/shared/tools/operations/getApiOperationList.ts
@@ -15,7 +15,7 @@ Uses the configured API specification: ${context.apiSpecificationPath}`;
   return `${baseDescription}
 
 It takes one argument:
-- apiSpecificationPath (str): The path to the API specification file e.g., '/open-finance-us/swagger/openfinance-us.yaml')`;
+- apiSpecificationPath (str): The path to the API specification file e.g., '/open-finance-us/swagger/openbanking-us.yaml')`;
 };
 
 export const getParameters = (context: ToolContext): z.ZodObject<any> => {
@@ -27,7 +27,7 @@ export const getParameters = (context: ToolContext): z.ZodObject<any> => {
     apiSpecificationPath: z
       .string()
       .describe(
-        'The path to the API specification file (e.g., /open-finance-us/swagger/openfinance-us.yaml)'
+        'The path to the API specification file (e.g., /open-finance-us/swagger/openbanking-us.yaml)'
       ),
   });
 };

--- a/typescript/src/shared/tools/operations/getApiOperationList.ts
+++ b/typescript/src/shared/tools/operations/getApiOperationList.ts
@@ -15,7 +15,7 @@ Uses the configured API specification: ${context.apiSpecificationPath}`;
   return `${baseDescription}
 
 It takes one argument:
-- apiSpecificationPath (str): The path to the API specification file e.g., '/open-banking-us/swagger/openbanking-us.yaml')`;
+- apiSpecificationPath (str): The path to the API specification file e.g., '/open-finance-us/swagger/openfinance-us.yaml')`;
 };
 
 export const getParameters = (context: ToolContext): z.ZodObject<any> => {
@@ -27,7 +27,7 @@ export const getParameters = (context: ToolContext): z.ZodObject<any> => {
     apiSpecificationPath: z
       .string()
       .describe(
-        'The path to the API specification file (e.g., /open-banking-us/swagger/openbanking-us.yaml)'
+        'The path to the API specification file (e.g., /open-finance-us/swagger/openfinance-us.yaml)'
       ),
   });
 };


### PR DESCRIPTION
Open Banking is now Open Finance (https://developer.mastercard.com/product/open-finance). This PR will rename all the relevant references.