### PR TITLE
Bump `developers-mcp` version

### DIFF
--- a/modelcontextprotocol/dxt/manifest.json
+++ b/modelcontextprotocol/dxt/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "mastercard-developers-mcp",
   "icon": "mastercard-icon.png",
-  "version": "0.1.3",
+  "version": "0.1.6",
   "display_name": "Mastercard Developers MCP",
   "description": "Access Mastercard Developers APIs, documentation, and specifications through MCP",
   "long_description": "This extension provides seamless access to Mastercard Developers APIs, comprehensive documentation, and API specifications. It enables developers to query available services, retrieve detailed API operation information, access documentation sections, and get integration guides directly.\n\n**Key Features:**\n- List all available Mastercard services\n- Access comprehensive documentation and specific sections\n- Retrieve OAuth 1.0a and Open Finance integration guides\n- Get detailed API operation information including parameters and schemas\n- Query API specifications and operation details\n\n**Use Cases:**\n- API discovery and exploration\n- Documentation lookup during development\n- Integration planning and implementation\n- Authentication and authorization guidance",

--- a/modelcontextprotocol/package-lock.json
+++ b/modelcontextprotocol/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mastercard/developers-mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mastercard/developers-mcp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@mastercard/developers-agent-toolkit": "0.1.4",
+        "@mastercard/developers-agent-toolkit": "0.1.5",
         "@modelcontextprotocol/sdk": "^1.27.1"
       },
       "bin": {
@@ -2067,9 +2067,9 @@
       }
     },
     "node_modules/@mastercard/developers-agent-toolkit": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@mastercard/developers-agent-toolkit/-/developers-agent-toolkit-0.1.4.tgz",
-      "integrity": "sha512-bc/CW3gyGI/byXiSBISZCijHgNcqdgaQQ0xIwpWvIQaTVCYgDRlqHbzpCXVI3+JuxbDWPBJKoUPKy99DQXZvqQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@mastercard/developers-agent-toolkit/-/developers-agent-toolkit-0.1.5.tgz",
+      "integrity": "sha512-U5JtvX1vod5obUi/zLZvtQMsX2/PbL/uxbPRi2uZgqCg5q4oNHbY98UqDrhHFT5fUKgAFN7I7OURLCQJ8ZaKYg==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/modelcontextprotocol/package.json
+++ b/modelcontextprotocol/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.5",
+  "version": "0.1.6",
   "name": "@mastercard/developers-mcp",
   "mcpName": "io.github.Mastercard/developers-mcp",
   "homepage": "https://github.com/mastercard/developers-agent-toolkit/tree/main/modelcontextprotocol",
@@ -65,7 +65,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@mastercard/developers-agent-toolkit": "0.1.4",
+    "@mastercard/developers-agent-toolkit": "0.1.5",
     "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "lint-staged": {

--- a/modelcontextprotocol/server.json
+++ b/modelcontextprotocol/server.json
@@ -8,12 +8,12 @@
     "source": "github",
     "subfolder": "modelcontextprotocol"
   },
-  "version": "0.1.0",
+  "version": "0.1.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@mastercard/developers-mcp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "transport": {
         "type": "stdio"
       }

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@mastercard/developers-agent-toolkit",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",


### PR DESCRIPTION
- Bump `developers-mcp` version to `0.1.6`
- Updated dependency version `@mastercard/developers-agent-toolkit` to `0.1.5`
- Bump DXT version: `0.1.6`