### PR TITLE
Support injectable client for OAuth guides

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mastercard/developers-agent-toolkit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mastercard/developers-agent-toolkit",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.5",
+  "version": "0.1.6",
   "name": "@mastercard/developers-agent-toolkit",
   "homepage": "https://github.com/mastercard/developers-agent-toolkit",
   "description": "Agent Toolkit for Mastercard Developers Platform",

--- a/typescript/src/shared/tools/documentation/__tests__/githubReadme.test.ts
+++ b/typescript/src/shared/tools/documentation/__tests__/githubReadme.test.ts
@@ -1,0 +1,59 @@
+import { fetchGithubReadme } from '@/shared/tools/documentation/githubReadme';
+import { createMockApi } from '@/tests/mockDevelopersApi';
+import fetch from 'node-fetch';
+
+jest.mock('node-fetch');
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+const mockApi = createMockApi();
+
+describe('fetchGithubReadme', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses fetchGithubGuide when provided and returns content on success', async () => {
+    const fetchGithubGuide = jest.fn().mockResolvedValue('github content');
+
+    const result = await fetchGithubReadme('oauth1-signer-java', {
+      client: { ...mockApi, fetchGithubGuide },
+    });
+
+    expect(fetchGithubGuide).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Mastercard/oauth1-signer-java/refs/heads/main/README.md'
+    );
+    expect(result).toBe('github content');
+  });
+
+  it('returns undefined when fetchGithubGuide is provided but fails', async () => {
+    const fetchGithubGuide = jest.fn().mockRejectedValue(new Error('network error'));
+
+    const result = await fetchGithubReadme('oauth1-signer-java', {
+      client: { ...mockApi, fetchGithubGuide },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('uses plain fetch when fetchGithubGuide is not provided and returns content on success', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('github content'),
+    } as any);
+
+    const result = await fetchGithubReadme('oauth1-signer-java', { client: mockApi });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/Mastercard/oauth1-signer-java/refs/heads/main/README.md'
+    );
+    expect(result).toBe('github content');
+  });
+
+  it('returns undefined when plain fetch response is not ok', async () => {
+    mockFetch.mockResolvedValue({ ok: false } as any);
+
+    const result = await fetchGithubReadme('oauth1-signer-java', { client: mockApi });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/typescript/src/shared/tools/documentation/__tests__/githubReadme.test.ts
+++ b/typescript/src/shared/tools/documentation/__tests__/githubReadme.test.ts
@@ -26,7 +26,9 @@ describe('fetchGithubReadme', () => {
   });
 
   it('returns undefined when fetchGithubGuide is provided but fails', async () => {
-    const fetchGithubGuide = jest.fn().mockRejectedValue(new Error('network error'));
+    const fetchGithubGuide = jest
+      .fn()
+      .mockRejectedValue(new Error('network error'));
 
     const result = await fetchGithubReadme('oauth1-signer-java', {
       client: { ...mockApi, fetchGithubGuide },
@@ -41,7 +43,9 @@ describe('fetchGithubReadme', () => {
       text: jest.fn().mockResolvedValue('github content'),
     } as any);
 
-    const result = await fetchGithubReadme('oauth1-signer-java', { client: mockApi });
+    const result = await fetchGithubReadme('oauth1-signer-java', {
+      client: mockApi,
+    });
 
     expect(mockFetch).toHaveBeenCalledWith(
       'https://raw.githubusercontent.com/Mastercard/oauth1-signer-java/refs/heads/main/README.md'
@@ -52,7 +56,9 @@ describe('fetchGithubReadme', () => {
   it('returns undefined when plain fetch response is not ok', async () => {
     mockFetch.mockResolvedValue({ ok: false } as any);
 
-    const result = await fetchGithubReadme('oauth1-signer-java', { client: mockApi });
+    const result = await fetchGithubReadme('oauth1-signer-java', {
+      client: mockApi,
+    });
 
     expect(result).toBeUndefined();
   });

--- a/typescript/src/shared/tools/documentation/getOAuth10aGuide.ts
+++ b/typescript/src/shared/tools/documentation/getOAuth10aGuide.ts
@@ -59,10 +59,12 @@ export const execute = async (
 
     if (repositoryName !== undefined) {
       const githubUrl = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
-      const response = await fetch(githubUrl);
-
-      if (response.ok) {
-        return await response.text();
+      if (context.client.fetchGithubGuide !== undefined) {
+        const content = await context.client.fetchGithubGuide(githubUrl).catch(() => undefined);
+        if (content !== undefined) return content;
+      } else {
+        const response = await fetch(githubUrl);
+        if (response.ok) return await response.text();
       }
     }
   }

--- a/typescript/src/shared/tools/documentation/getOAuth10aGuide.ts
+++ b/typescript/src/shared/tools/documentation/getOAuth10aGuide.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import fetch from 'node-fetch';
 import { Tool, ToolContext } from '@/shared/types';
+import { fetchGithubReadme } from './githubReadme';
 
 const getDescription = (): string => {
   return `Retrieves the comprehensive OAuth 1.0a integration guide including step-by-step instructions,
@@ -58,15 +58,9 @@ export const execute = async (
     }
 
     if (repositoryName !== undefined) {
-      const githubUrl = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
-      if (context.client.fetchGithubGuide !== undefined) {
-        const content = await context.client
-          .fetchGithubGuide(githubUrl)
-          .catch(() => undefined);
-        if (content !== undefined) return content;
-      } else {
-        const response = await fetch(githubUrl);
-        if (response.ok) return await response.text();
+      const content = await fetchGithubReadme(repositoryName, context);
+      if (content !== undefined) {
+        return content;
       }
     }
   }

--- a/typescript/src/shared/tools/documentation/getOAuth10aGuide.ts
+++ b/typescript/src/shared/tools/documentation/getOAuth10aGuide.ts
@@ -60,7 +60,9 @@ export const execute = async (
     if (repositoryName !== undefined) {
       const githubUrl = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
       if (context.client.fetchGithubGuide !== undefined) {
-        const content = await context.client.fetchGithubGuide(githubUrl).catch(() => undefined);
+        const content = await context.client
+          .fetchGithubGuide(githubUrl)
+          .catch(() => undefined);
         if (content !== undefined) return content;
       } else {
         const response = await fetch(githubUrl);

--- a/typescript/src/shared/tools/documentation/getOAuth20Guide.ts
+++ b/typescript/src/shared/tools/documentation/getOAuth20Guide.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import fetch from 'node-fetch';
 import { Tool, ToolContext } from '@/shared/types';
+import { fetchGithubReadme } from './githubReadme';
 
 const getDescription = (): string => {
   return `Retrieves the comprehensive OAuth 2.0 integration guide including step-by-step instructions,
@@ -40,15 +40,9 @@ export const execute = async (
     }
 
     if (repositoryName !== undefined) {
-      const githubUrl = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
-      if (context.client.fetchGithubGuide !== undefined) {
-        const content = await context.client
-          .fetchGithubGuide(githubUrl)
-          .catch(() => undefined);
-        if (content !== undefined) return content;
-      } else {
-        const response = await fetch(githubUrl);
-        if (response.ok) return await response.text();
+      const content = await fetchGithubReadme(repositoryName, context);
+      if (content !== undefined) {
+        return content;
       }
     }
   }

--- a/typescript/src/shared/tools/documentation/getOAuth20Guide.ts
+++ b/typescript/src/shared/tools/documentation/getOAuth20Guide.ts
@@ -41,10 +41,12 @@ export const execute = async (
 
     if (repositoryName !== undefined) {
       const githubUrl = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
-      const response = await fetch(githubUrl);
-
-      if (response.ok) {
-        return await response.text();
+      if (context.client.fetchGithubGuide !== undefined) {
+        const content = await context.client.fetchGithubGuide(githubUrl).catch(() => undefined);
+        if (content !== undefined) return content;
+      } else {
+        const response = await fetch(githubUrl);
+        if (response.ok) return await response.text();
       }
     }
   }

--- a/typescript/src/shared/tools/documentation/getOAuth20Guide.ts
+++ b/typescript/src/shared/tools/documentation/getOAuth20Guide.ts
@@ -42,7 +42,9 @@ export const execute = async (
     if (repositoryName !== undefined) {
       const githubUrl = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
       if (context.client.fetchGithubGuide !== undefined) {
-        const content = await context.client.fetchGithubGuide(githubUrl).catch(() => undefined);
+        const content = await context.client
+          .fetchGithubGuide(githubUrl)
+          .catch(() => undefined);
         if (content !== undefined) return content;
       } else {
         const response = await fetch(githubUrl);

--- a/typescript/src/shared/tools/documentation/githubReadme.ts
+++ b/typescript/src/shared/tools/documentation/githubReadme.ts
@@ -1,0 +1,14 @@
+import fetch from 'node-fetch';
+import { ToolContext } from '@/shared/types';
+
+export async function fetchGithubReadme(
+  repositoryName: string,
+  context: ToolContext
+): Promise<string | undefined> {
+  const url = `https://raw.githubusercontent.com/Mastercard/${repositoryName}/refs/heads/main/README.md`;
+  if (context.client.fetchGithubGuide !== undefined) {
+    return context.client.fetchGithubGuide(url).catch(() => undefined);
+  }
+  const response = await fetch(url);
+  return response.ok ? response.text() : undefined;
+}

--- a/typescript/src/shared/types.ts
+++ b/typescript/src/shared/types.ts
@@ -24,6 +24,7 @@ export interface DevelopersApi {
     method: string,
     path: string
   ): Promise<string>;
+  fetchGithubGuide?(url: string): Promise<string>;
 }
 
 export interface ToolContext {


### PR DESCRIPTION
- Add an optional `fetchGithubGuide` method to `DevelopersApi` that allows consumers to provide a custom HTTP client for fetching language-specific OAuth guide READMEs from GitHub.
- Bump version to 0.1.6